### PR TITLE
Jh/chore/intcode setup

### DIFF
--- a/intcode/intcode.py
+++ b/intcode/intcode.py
@@ -1,20 +1,21 @@
 class IntCode:
-    def __init__(self, input_file, inputs=None):
+    def __init__(self, registers, inputs=None):
         self._addr = 0
         self._input_addr = 0
+        self._run = True
 
         if inputs is None:
             self._inputs = []
         else:
             self._inputs = inputs
 
-        with open(input_file, 'r') as fh:
-            reg_vals = list(map(int, fh.readline().split(',')))
-            reg_addrs = list(range(len(reg_vals)))
-            self.regs = dict(zip(reg_addrs, reg_vals))
+        register_addresses = list(range(len(registers)))
+        self._registers = dict(zip(register_addresses, registers))
 
     def run(self):
-        while True:
+        self._run = True
+
+        while self._run:
             opcode = self._get_opcode()
             modes = self._get_modes()
 
@@ -25,7 +26,8 @@ class IntCode:
             elif opcode == 3:
                 self._inp(modes)
             elif opcode == 4:
-                self._out(modes)
+                output = self._out(modes)
+                return output
             elif opcode == 5:
                 self._jeq(modes)
             elif opcode == 6:
@@ -41,10 +43,10 @@ class IntCode:
                 break
 
     def set_reg_val(self, addr, val):
-        self.regs[addr] = val
+        self._registers[addr] = val
 
     def get_reg_val(self, addr):
-        return self.regs[addr]
+        return self._registers[addr]
 
     def _get_opcode(self):
         return self.get_reg_val(self._addr) % 100
@@ -75,8 +77,9 @@ class IntCode:
 
     def _out(self, modes):
         output = self._get_param(self._addr + 1, modes[0])
-        print(f"Outputting a value! The value is {output}!")
         self._addr += 2
+        self._run = False
+        return output
 
     def _jeq(self, modes):
         param_1 = self._get_param(self._addr + 1, modes[0])
@@ -116,10 +119,10 @@ class IntCode:
 
     def _get_param(self, addr, mode):
         if mode == 1:
-            return self.regs[addr]
+            return self._registers[addr]
         elif mode == 0:
-            addr = self.regs[addr]
-            return self.regs[addr]
+            addr = self._registers[addr]
+            return self._registers[addr]
 
     def _get_write_addr(self, addr):
-        return self.regs[addr]
+        return self._registers[addr]

--- a/solutions/02.py
+++ b/solutions/02.py
@@ -14,10 +14,13 @@ def main():
 
 
 def part_1(input_file):
-    intcode = IntCode(input_file)
+    with open(input_file, 'r') as fh:
+        registers = list(map(int, fh.readline().split(',')))
 
-    intcode.set_reg_val(1, 12)
-    intcode.set_reg_val(2, 2)
+    registers[1] = 12
+    registers[2] = 2
+
+    intcode = IntCode(registers)
 
     intcode.run()
 
@@ -25,11 +28,14 @@ def part_1(input_file):
 
 
 def part_2(input_file):
+    with open(input_file, 'r') as fh:
+        registers = list(map(int, fh.readline().split(',')))
+
     for i in range(100):
+        registers[1] = i
         for j in range(100):
-            intcode = IntCode(input_file)
-            intcode.set_reg_val(1, i)
-            intcode.set_reg_val(2, j)
+            registers[2] = j
+            intcode = IntCode(registers)
             intcode.run()
             if intcode.get_reg_val(0) == 19690720:
                 return 100*i + j

--- a/solutions/05.py
+++ b/solutions/05.py
@@ -3,10 +3,20 @@ from intcode.intcode import IntCode
 
 def main():
     input_file = '../inputs/05.txt'
-    intcode = IntCode(input_file, [1])
-    intcode.run()
-    intcode = IntCode(input_file, [5])
-    intcode.run()
+
+    with open(input_file, 'r') as fh:
+        registers = list(map(int, fh.readline().split(',')))
+
+    intcode = IntCode(registers, [1])
+    while True:
+        output = intcode.run()
+        if output != 0:
+            part_1 = output
+            break
+    intcode = IntCode(registers, [5])
+    part_2 = intcode.run()
+    print(f"The solution to part 1 is {part_1}.")
+    print(f"The solution to part 2 is {part_2}.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Change intcode to be initialized with a list, instead of a file path. This minimizes file reads for cases where many Intcode computers must be generated. 